### PR TITLE
chore: launch Swagger UI at root URL

### DIFF
--- a/TokenService/Controllers/AuthController.cs
+++ b/TokenService/Controllers/AuthController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using Microsoft.IdentityModel.Tokens;
+using Swashbuckle.AspNetCore.Annotations;
 using System.IdentityModel.Tokens.Jwt;
 using System.Text;
 using TokenService.Services;
@@ -25,6 +26,10 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("token")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "JWT-token genererades korrekt")]
+    [SwaggerResponse(400, "Ogiltig request – userId eller role saknas")]
+    [SwaggerOperation (Summary = "Genererar en JWT-token baserat på användarens ID och roll.")] 
     public IActionResult GenerateToken([FromBody] TokenRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.UserId) || string.IsNullOrWhiteSpace(request.Role))
@@ -44,6 +49,11 @@ public class AuthController : ControllerBase
    4. Returnerar 200 OK om token är giltig, annars 401 Unauthorized */
 
     [HttpGet("validate")]
+    [Produces("application/json")]
+    [SwaggerResponse(200, "Token är giltig")]
+    [SwaggerResponse(401, "Token saknas, är ogiltig eller har gått ut")]
+    [SwaggerResponse(500, "JWT-konfiguration saknas i servern")]
+    [SwaggerOperation(Summary = "Validerar en JWT-token från Authorization-header.")]
     public IActionResult ValidateToken()
     {
         var authHeader = Request.Headers["Authorization"].ToString();

--- a/TokenService/Controllers/AuthController.cs
+++ b/TokenService/Controllers/AuthController.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using TokenService.Services;
+
+namespace TokenService.Controllers;
+
+/* Denna controller genererades med hjälp av ChatGPT-4o
+   Syfte: Tar emot ett userId och role via POST /auth/token,
+   validerar input, och använder ITokenService för att generera en JWT-token.
+   TokenRequest-klassen används som modell för inkommande data. */
+[ApiController]
+[Route("auth")]
+public class AuthController : ControllerBase
+{
+    private readonly ITokenService _tokenService;
+
+    public AuthController(ITokenService tokenService)
+    {
+        _tokenService = tokenService;
+    }
+
+    [HttpPost("token")]
+    public IActionResult GenerateToken([FromBody] TokenRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserId) || string.IsNullOrWhiteSpace(request.Role))
+        {
+            return BadRequest("UserId and Role are required.");
+        }
+
+        var token = _tokenService.GenerateToken(request.UserId, request.Role);
+        return Ok(new { token });
+    }
+}
+
+public class TokenRequest
+{
+    public string? UserId { get; set; }
+    public string? Role { get; set; }
+}
+

--- a/TokenService/Program.cs
+++ b/TokenService/Program.cs
@@ -1,3 +1,4 @@
+using Microsoft.OpenApi.Models;
 using TokenService.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -6,7 +7,42 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 builder.Services.AddScoped<ITokenService, JwtTokenService>();
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+
+/* Swagger med JWT-support
+   Denna konfiguration genererades med hjälp av ChatGPT-4o
+   Lägger till en "Authorize"-knapp i Swagger UI som möjliggör testning av endpoints med JWT.
+   1. Definierar säkerhetsdefinition för Bearer-token
+   2. Tillämpas globalt via AddSecurityRequirement */
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new() { Title = "TokenService API", Version = "v1" });
+
+    c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "Bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "Klistra in endast din JWT-token här. Swagger lägger automatiskt till 'Bearer'."
+    });
+
+    c.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
+});
+
 
 var app = builder.Build();
 

--- a/TokenService/Program.cs
+++ b/TokenService/Program.cs
@@ -1,23 +1,20 @@
+using TokenService.Services;
+
 var builder = WebApplication.CreateBuilder(args);
 
-// Add services to the container.
 
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddScoped<ITokenService, JwtTokenService>();
 builder.Services.AddOpenApi();
 
 var app = builder.Build();
 
-// Configure the HTTP request pipeline.
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
-
 app.MapControllers();
-
 app.Run();

--- a/TokenService/Program.cs
+++ b/TokenService/Program.cs
@@ -2,19 +2,22 @@ using TokenService.Services;
 
 var builder = WebApplication.CreateBuilder(args);
 
-
+// Services
 builder.Services.AddControllers();
 builder.Services.AddScoped<ITokenService, JwtTokenService>();
-builder.Services.AddOpenApi();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
 
-if (app.Environment.IsDevelopment())
-{
-    app.MapOpenApi();
-}
-
+// Middleware
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();
+
+// Swagger
+app.UseSwagger();
+app.UseSwaggerUI();
+
+
 app.Run();

--- a/TokenService/Program.cs
+++ b/TokenService/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.OpenApi.Models;
 using TokenService.Services;
 
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Services
@@ -16,6 +17,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
     c.SwaggerDoc("v1", new() { Title = "TokenService API", Version = "v1" });
+    c.EnableAnnotations();
 
     c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {

--- a/TokenService/Program.cs
+++ b/TokenService/Program.cs
@@ -55,7 +55,11 @@ app.MapControllers();
 
 // Swagger
 app.UseSwagger();
-app.UseSwaggerUI();
+app.UseSwaggerUI(c =>
+{
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", "TokenService API v1");
+    c.RoutePrefix = string.Empty;
+});
 
 
 app.Run();

--- a/TokenService/Services/ITokenService.cs
+++ b/TokenService/Services/ITokenService.cs
@@ -1,0 +1,6 @@
+﻿namespace TokenService.Services;
+
+public interface ITokenService
+{
+    string GenerateToken(string userId, string role);
+}

--- a/TokenService/Services/JwtTokenService.cs
+++ b/TokenService/Services/JwtTokenService.cs
@@ -1,0 +1,10 @@
+﻿namespace TokenService.Services;
+
+public class JwtTokenService : ITokenService
+{
+    public string GenerateToken(string userId, string role)
+    {
+        // Placeholder – riktig JWT kommer senare
+        return $"Generated token for {userId} with role {role}";
+    }
+}

--- a/TokenService/Services/JwtTokenService.cs
+++ b/TokenService/Services/JwtTokenService.cs
@@ -1,10 +1,55 @@
-﻿namespace TokenService.Services;
+﻿using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+
+namespace TokenService.Services;
 
 public class JwtTokenService : ITokenService
 {
+    private readonly IConfiguration _config;
+
+    public JwtTokenService(IConfiguration config)
+    {
+        _config = config;
+    }
+
+    /* Denna metod genererades med hjälp av ChatGPT-4o
+   Skapar en signerad JWT-token som innehåller användarens ID och roll som claims.
+   Nyckeln hämtas från appsettings.json via IConfiguration.
+   1. Hämtar och kontrollerar JWT-nyckel
+   2. Skapar nyckel, signeringsuppgifter och claims
+   3. Returnerar signerad token som sträng */
+
     public string GenerateToken(string userId, string role)
     {
-        // Placeholder – riktig JWT kommer senare
-        return $"Generated token for {userId} with role {role}";
+        var secret = _config["Jwt:Key"];
+        var issuer = _config["Jwt:Issuer"];
+        var audience = _config["Jwt:Audience"];
+
+        if (string.IsNullOrEmpty(secret))
+        {
+            throw new InvalidOperationException("JWT secret key is not configured.");
+        }
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+        new Claim(JwtRegisteredClaimNames.Sub, userId),
+        new Claim(ClaimTypes.Role, role),
+        new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString())
+    };
+
+        var token = new JwtSecurityToken(
+            issuer: issuer,
+            audience: audience,
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds
+        );
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 }

--- a/TokenService/TokenService.csproj
+++ b/TokenService/TokenService.csproj
@@ -10,8 +10,4 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Controllers\" />
-  </ItemGroup>
-
 </Project>

--- a/TokenService/TokenService.csproj
+++ b/TokenService/TokenService.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="8.1.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />
   </ItemGroup>
 

--- a/TokenService/TokenService.csproj
+++ b/TokenService/TokenService.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Denna PR gör så att Swagger UI öppnas automatiskt vid root `(https://localhost:xxxx/)` när tjänsten startas.

Förändringar:
- Lagt till RoutePrefix = string.Empty i app.UseSwaggerUI()
- Swagger är nu tillgänglig direkt utan att behöva skriva /swagger manuellt