### PR TITLE
chore: update README with Azure URL and ignore profile.arm.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,5 @@ MigrationBackup/
 FodyWeavers.xsd
 
 appsettings.json
+
+**/profile.arm.json

--- a/README.md
+++ b/README.md
@@ -112,8 +112,11 @@ Täckta scenarier:
 
 ## Publicering
 
-TokenService är ännu inte publicerad till Azure.  
-Kommer att göras tillgänglig under molntjänst vid behov.
+TokenService är publicerad på Azure:
+
+🔗 [https://tokenservice-hghjfwgwf9cubxdp.swedencentral-01.azurewebsites.net](https://tokenservice-hghjfwgwf9cubxdp.swedencentral-01.azurewebsites.net)
+
+Tjänsten innehåller Swagger UI där du kan testa `/auth/token` och `/auth/validate`.
 
 
 ---


### PR DESCRIPTION
Lägger till länk till publicerad TokenService i README
Ignorerar profile.arm.json från versionshantering